### PR TITLE
sort_rxn back in parser ckin

### DIFF
--- a/mechanalyzer/parser/ckin_.py
+++ b/mechanalyzer/parser/ckin_.py
@@ -7,7 +7,7 @@ import chemkin_io
 import numpy as np
 
 
-def parse(mech_str, spc_dct):
+def parse(mech_str, spc_dct,sort_rxns):
     """ parse a chemkin formatted mechanism file
     """
 
@@ -49,6 +49,14 @@ def parse(mech_str, spc_dct):
         formula_dct_lst.append(formula_dct)
         formula_str_lst.append(formula_str)
 
+    rxn_info_lst = list(	    
+        zip(formula_dct_lst, formula_str_lst, rct_names_lst, prd_names_lst, rxn_name_lst))	
+
+    # Sort the reactions if desired	
+    if sort_rxns:	
+        rxn_info_lst.sort()	
+        formula_dct_lst,formula_str_lst, rct_names_lst, prd_names_lst, rxn_name_lst = zip(	
+            *rxn_info_lst)
     return formula_dct_lst, formula_str_lst, rct_names_lst, prd_names_lst, rxn_name_lst
 
 

--- a/mechanalyzer/parser/pes.py
+++ b/mechanalyzer/parser/pes.py
@@ -11,14 +11,14 @@ import os
 import ioformat
 
 # PARSE THE MECHANISM FIle 
-def read_mechanism_file(mech_str, mech_type, spc_dct):
+def read_mechanism_file(mech_str, mech_type, spc_dct, sort_rxns=False):
     """ Get the reactions and species from the mechanism input
     """
 
     # Parse the info from the chemkin file
     if mech_type == 'chemkin':
         formulas_dct, formulas, rct_names, prd_names, rxn_names = ckin.parse(
-            mech_str, spc_dct)
+            mech_str, spc_dct,sort_rxns)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
the parser works like before the last commit
The only change is that the output of parser.pes.read_mechanism_file and parser.ckin.parse have 5 outputs instead of 4. The first is the new one and is the dictionary of formulas (I need it for the sorting)