### PR TITLE
Refined Wrappers and Tests, Working on Setter

### DIFF
--- a/xarray_wrappers.py
+++ b/xarray_wrappers.py
@@ -1,87 +1,95 @@
+"""
+Wrappers for the new xarray system. Constructors, Getters, then Setters.
+"""
+
 import xarray
-import numpy
 
 # Constructors
-def from_data(temps, press, ktp_vals):
-    # WORK IN PROGRESS - SHOULD NOT WORK YET JUST TESTING THINGS OUT
-    # Construct a KTP DataArray from data
+def from_data(temps, press, rates):
+    """
+    Construct a KTP DataArray from data
+    """
 
-    ktp = xarray.DataArray(ktp_vals, [("pres", press), ("temp", temps)])
+    ktp = xarray.DataArray(rates, [("pres", press), ("temp", temps)])
 
     return ktp
 
 
+
 # Getters
-def get_temperatures(ktp):
-    # WORK IN PROGRESS
-    # Gets the temperature values
-
-    return (list(ktp["temp"]))
-
-
 def get_pressures(ktp):
-    # WORK IN PROGRESS
-    # Gets the pressure values
+    """
+    Gets the temperature values
+    """
 
-    return (list(ktp["pres"]))
+    return ktp.pres.data
 
 
-def get_values(ktp_vals):
-    # WORK IN PROGRESS
-    # Gets the KTP values
+def get_temperatures(ktp):
+    """
+    Gets the pressure values
+    """
 
-    return (ktp_vals)
+    return ktp.temp.data
 
-def get_pslice(ktp):
-    # WORK IN PROGRESS
-    # Get a slice at a selected pressure value
 
-    return (ktp.sel(pres = numpy.inf))
+def get_values(rates):
+    """
+    WORK IN PROGRESS
+    Gets the KTP values
+    """
 
-def get_tslice(ktp, t):
-    # WORK IN PROGRESS
-    # Get a slice at a selected temperature value
+    return rates
 
-    return(ktp.sel(temp = t))
 
-def get_spec_vals(ktp, t, p):
-    # WORK IN PROGRESS
-    # Get a specific value at a selected temperature and pressure value
+def get_pslice(ktp, ip):
+    """
+    Get a slice at a selected pressure value
+    """
 
-    return (ktp.sel(temp = t, pres = p))
+    return ktp.sel(pres=ip)
 
-def get_ipslice(ktp, i):
-    # WORK IN PROGRESS
-    # Get a slice at a selected pressure index
 
-    return(ktp.isel(pres = i))
+def get_tslice(ktp, it):
+    """
+    Get a slice at a selected temperature value
+    """
 
-def get_itslice(ktp, i):
-    # WORK IN PROGRESS
-    # Get a slice at a selected temperature index
+    return ktp.sel(temp=it)
 
-    return (ktp.isel(temp = i))
 
-def get_dims(ktp):
-    # WORK IN PROGRESS
-    # Get all dimensions associated with an array
+def get_spec_vals(ktp, it, ip):
+    """
+    Get a specific value at a selected temperature and pressure value
+    """
 
-    return(ktp.dims)
+    return ktp.sel(temp=it, pres=ip)
 
-def get_t_coords(ktp):
-    # WORK IN PROGRESS
-    # Get co-ordinates associated with a dimension for temperature
-    
-    return(ktp.temp.data)
 
-def get_p_coords(ktp):
-    # WORK IN PROGRESS
-    # Get co-ordinates associated with a dimension for pressure
+def get_ipslice(ktp, ip):
+    """
+    Get a slice at a selected pressure index
+    """
 
-    return(ktp.pres.data)
+    return ktp.isel(pres=ip)
+
+
+def get_itslice(ktp, it):
+    """
+    Get a slice at a selected temperature index
+    """
+
+    return ktp.isel(temp=it)
+
 
 
 # Setters
-def set_values(ktp_vals):
-    # WORK IN PROGRESSS
-    # Sets the KTP values
+def set_rates(ktp, rates):
+    """
+    DOES NOT WORK YET. Still fixing!
+    Sets the KTP values
+    """
+
+    #ktp = ktp.loc[rates]
+    #return ktp
+    pass

--- a/xarray_wrappers_test.py
+++ b/xarray_wrappers_test.py
@@ -2,50 +2,62 @@ import xarray_wrappers
 import xarray
 import numpy
 
-temps = [1000, 1500, 2000, 2500]
-press = [1, 10, numpy.inf]
-ktp_vals = [[1e1, 1e2, 1e3, 1e4], [1e5, 1e6, 1e7, 1e8], [1e9, 1e10, 1e11, 1e12]]
+Temps = [1000, 1500, 2000, 2500]
+Press = [1, 10, numpy.inf]
+Rates = [[1e1, 1e2, 1e3, 1e4], [1e5, 1e6, 1e7, 1e8], [1e9, 1e10, 1e11, 1e12]]
 
-ktp = xarray_wrappers.from_data(temps, press, ktp_vals)
-print(ktp)
+Ktp = xarray_wrappers.from_data(Temps, Press, Rates)
+print(Ktp)
+
+def test_set_rates():
+    ktp = xarray_wrappers.set_rates(Ktp, Rates)
+    print(ktp)
 
 def test_get_temperatures():
-    temp = xarray_wrappers.get_temperatures(ktp)
+    temp = xarray_wrappers.get_temperatures(Ktp)
     print(temp)
 
+
 def test_get_pressures():
-    pres = xarray_wrappers.get_pressures(ktp)
+    pres = xarray_wrappers.get_pressures(Ktp)
     print(pres)
 
+
 def test_get_values():
-    vals = xarray_wrappers.get_values(ktp_vals)
+    vals = xarray_wrappers.get_values(Rates)
     print(vals)
+
 
 def test_get_pslice():
-    pslice = xarray_wrappers.get_pslice(ktp)
+    pslice = xarray_wrappers.get_pslice(Ktp, numpy.inf)
     print(pslice)
 
+
 def test_get_tslice():
-    tslice = xarray_wrappers.get_tslice(ktp)
+    tslice = xarray_wrappers.get_tslice(Ktp, 1500)
     print(tslice)
 
+
 def test_get_spec_vals():
-    vals = xarray_wrappers.get_spec_vals(ktp, temp = 1500, pres = 1)
+    vals = xarray_wrappers.get_spec_vals(Ktp, 1500, 1)
     print(vals)
 
+
 def test_get_ipslice():
-    ipslice = xarray_wrappers.get_ipslice(ktp, i = 0)
+    ipslice = xarray_wrappers.get_ipslice(Ktp, 0)
     print(ipslice)
 
-def test_get_itslice():
-    itslice = xarray_wrappers.get_itslice(ktp, i = 0)
-    print(itslice)
 
-test_get_temperatures()
+def test_get_itslice():
+    itslice = xarray_wrappers.get_itslice(Ktp, 0)
+    print(itslice)
+    
+test_set_rates()
 test_get_pressures()
+test_get_temperatures()
 test_get_values()
 test_get_pslice()
 test_get_tslice()
 test_get_spec_vals()
 test_get_ipslice()
-test_getitslice()
+test_get_itslice()


### PR DESCRIPTION
Updated and refined several of the xarray wrappers:

Snake case global variables (first letter caps)
from_data: rename ktp_vals to rates
get_pslice: Add index
Formatting: Add more than 1 letter to variables (Pylint will get mad) (EX: idx instead of i)temperatures array and rates array
get_temp/get_pres: Make it output as ktp.pres.data and ktp.temp.data
Remove return parentheses
Replace all # with """ """
Two spaces after the end of return statements
Remove the bottom 2 getters (get_p_coords, get_t_coords) and get_dims
Also just debug overall

set_rates is still non-functional, and its contents have been commented out until fixed.