### PR TITLE
Uncommented Automatic pytest for mechanalyzer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,4 +39,4 @@ jobs:
 
           # # broken:
           # pixi run pytest -v thermfit
-          # pixi run pytest -v mechanalyzer
+          pixi run pytest -v mechanalyzer


### PR DESCRIPTION
As all tests currently run in mechanalyzer, the pytest that locates which commit broke a certain was uncommented.