### PR TITLE
Fix: Reading species.csv with trailing spaces

### DIFF
--- a/mechanalyzer/parser/new_spc.py
+++ b/mechanalyzer/parser/new_spc.py
@@ -376,8 +376,8 @@ def parse_line(line, idx, headers, quotechar="'"):
         :return cols: a list of the entries in the line
         :rtype: list
     """
-
-    cols = next(csv.reader([line], quotechar=quotechar))
+    # The `csv` module can't handle trailing spaces, so strip the line before reading
+    cols = next(csv.reader([line.strip()], quotechar=quotechar))
     if line == '':
         cols = None
     else:


### PR DESCRIPTION
There is a bug in the python csv module for trailing spaces in a CSV file:

```
>>> import csv

>>> line = "1,2,'abc','InChI=1S/H2O2/c1-2/h1-2H'                      "
>>> next(csv.reader([line], quotechar="'"))
['1', '2', 'abc', 'InChI=1S/H2O2/c1-2/h1-2H                      ']
```

This circumvents the bug by stripping the line before parsing.